### PR TITLE
ProxyOptions exposes ProxySelector, remove proxy settings from OtlpGr…

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -77,6 +77,7 @@ val DEPENDENCIES = listOf(
   "org.codehaus.mojo:animal-sniffer-annotations:1.23",
   "org.jctools:jctools-core:4.0.2",
   "org.junit-pioneer:junit-pioneer:1.9.1",
+  "org.mock-server:mockserver-netty:5.15.0:shaded",
   "org.skyscreamer:jsonassert:1.5.1",
   "com.android.tools:desugar_jdk_libs:2.0.4",
 )

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,19 +1,10 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setProxy(io.opentelemetry.sdk.common.export.ProxyOptions)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setProxyOptions(io.opentelemetry.sdk.common.export.ProxyOptions)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setProxy(io.opentelemetry.sdk.common.export.ProxyOptions)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setProxyOptions(io.opentelemetry.sdk.common.export.ProxyOptions)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setProxy(io.opentelemetry.sdk.common.export.ProxyOptions)
-***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder setProxy(io.opentelemetry.sdk.common.export.ProxyOptions)
-***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setProxy(io.opentelemetry.sdk.common.export.ProxyOptions)
-***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setProxy(io.opentelemetry.sdk.common.export.ProxyOptions)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -1,9 +1,2 @@
 Comparing source compatibility of  against 
-***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setEncoder(zipkin2.codec.BytesEncoder<zipkin2.Span><zipkin2.Span>)
-		+++  NEW ANNOTATION: java.lang.Deprecated
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setEncoder(zipkin2.reporter.BytesEncoder<zipkin2.Span>)
-	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setSender(zipkin2.reporter.Sender)
-		+++  NEW ANNOTATION: java.lang.Deprecated
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setSender(zipkin2.reporter.BytesMessageSender)
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,11 +1,8 @@
 Comparing source compatibility of  against 
-+++  NEW CLASS: PUBLIC(+) io.opentelemetry.sdk.common.export.ProxyOptions  (not serializable)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.common.export.ProxyOptions  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.export.ProxyOptions$ProxyOptionsBuilder builder(java.lang.String, int)
-	+++  NEW METHOD: PUBLIC(+) java.lang.String getHost()
-	+++  NEW METHOD: PUBLIC(+) int getPort()
-+++  NEW CLASS: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.export.ProxyOptions$ProxyOptionsBuilder  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.export.ProxyOptions build()
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.export.ProxyOptions create(java.net.ProxySelector)
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.common.export.ProxyOptions create(java.net.InetSocketAddress)
+	+++  NEW METHOD: PUBLIC(+) java.net.ProxySelector getProxySelector()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -14,7 +14,6 @@ import io.opentelemetry.exporter.internal.ExporterBuilderUtil;
 import io.opentelemetry.exporter.internal.TlsConfigHelper;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.time.Duration;
@@ -53,7 +52,6 @@ public class GrpcExporterBuilder<T extends Marshaler> {
       grpcStubFactory;
 
   private long timeoutNanos;
-  @Nullable private ProxyOptions proxyOptions;
   private URI endpoint;
   @Nullable private Compressor compressor;
   private final Map<String, String> constantHeaders = new HashMap<>();
@@ -92,11 +90,6 @@ public class GrpcExporterBuilder<T extends Marshaler> {
 
   public GrpcExporterBuilder<T> setTimeout(Duration timeout) {
     return setTimeout(timeout.toNanos(), TimeUnit.NANOSECONDS);
-  }
-
-  public GrpcExporterBuilder<T> setProxy(ProxyOptions proxyOptions) {
-    this.proxyOptions = proxyOptions;
-    return this;
   }
 
   public GrpcExporterBuilder<T> setEndpoint(String endpoint) {
@@ -168,7 +161,6 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     }
     copy.meterProviderSupplier = meterProviderSupplier;
     copy.grpcChannel = grpcChannel;
-    copy.proxyOptions = proxyOptions;
     return copy;
   }
 
@@ -202,7 +194,6 @@ public class GrpcExporterBuilder<T extends Marshaler> {
             compressor,
             timeoutNanos,
             headerSupplier,
-            proxyOptions,
             grpcChannel,
             grpcStubFactory,
             retryPolicy,
@@ -223,7 +214,6 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     joiner.add("endpoint=" + endpoint.toString());
     joiner.add("endpointPath=" + grpcEndpointPath);
     joiner.add("timeoutNanos=" + timeoutNanos);
-    joiner.add("proxyOptions=" + proxyOptions);
     joiner.add(
         "compressorEncoding="
             + Optional.ofNullable(compressor).map(Compressor::getEncoding).orElse(null));

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderProvider.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderProvider.java
@@ -8,7 +8,6 @@ package io.opentelemetry.exporter.internal.grpc;
 import io.grpc.Channel;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.util.List;
@@ -36,7 +35,6 @@ public interface GrpcSenderProvider {
       @Nullable Compressor compressor,
       long timeoutNanos,
       Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable ProxyOptions proxyOptions,
       @Nullable Object managedChannel,
       Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       @Nullable RetryPolicy retryPolicy,

--- a/exporters/otlp/all/src/jmh/java/io/opentelemetry/exporter/otlp/trace/OltpExporterBenchmark.java
+++ b/exporters/otlp/all/src/jmh/java/io/opentelemetry/exporter/otlp/trace/OltpExporterBenchmark.java
@@ -103,7 +103,6 @@ public class OltpExporterBenchmark {
                 Collections::emptyMap,
                 null,
                 null,
-                null,
                 null),
             MeterProvider::noop);
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -172,9 +172,9 @@ public final class OtlpHttpLogRecordExporterBuilder {
     return this;
   }
 
-  /** Sets the proxy to be used. */
-  public OtlpHttpLogRecordExporterBuilder setProxy(ProxyOptions proxyOptions) {
-    requireNonNull(proxyOptions, "proxyHost");
+  /** Sets the proxy options. Proxying is disabled by default. */
+  public OtlpHttpLogRecordExporterBuilder setProxyOptions(ProxyOptions proxyOptions) {
+    requireNonNull(proxyOptions, "proxyOptions");
     delegate.setProxy(proxyOptions);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -216,8 +216,8 @@ public final class OtlpHttpMetricExporterBuilder {
     return this;
   }
 
-  /** Sets the proxy to be used. */
-  public OtlpHttpMetricExporterBuilder setProxy(ProxyOptions proxyOptions) {
+  /** Sets the proxy options. Proxying is disabled by default. */
+  public OtlpHttpMetricExporterBuilder setProxyOptions(ProxyOptions proxyOptions) {
     requireNonNull(proxyOptions, "proxyOptions");
     delegate.setProxy(proxyOptions);
     return this;

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -173,7 +173,7 @@ public final class OtlpHttpSpanExporterBuilder {
     return this;
   }
 
-  /** Sets the proxy to be used. */
+  /** Sets the proxy options. Proxying is disabled by default. */
   public OtlpHttpSpanExporterBuilder setProxy(ProxyOptions proxyOptions) {
     requireNonNull(proxyOptions, "proxyOptions");
     delegate.setProxy(proxyOptions);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.sdk.metrics.Aggregation.explicitBucketHistogram;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -64,8 +63,7 @@ public final class OtlpConfigUtil {
       Consumer<Duration> setTimeout,
       Consumer<byte[]> setTrustedCertificates,
       BiConsumer<byte[], byte[]> setClientTls,
-      Consumer<RetryPolicy> setRetryPolicy,
-      Consumer<ProxyOptions> setProxy) {
+      Consumer<RetryPolicy> setRetryPolicy) {
     String protocol = getOtlpProtocol(dataType, config);
     boolean isHttpProtobuf = protocol.equals(PROTOCOL_HTTP_PROTOBUF);
     URL endpoint =
@@ -154,12 +152,6 @@ public final class OtlpConfigUtil {
         config.getBoolean("otel.experimental.exporter.otlp.retry.enabled", false);
     if (retryEnabled) {
       setRetryPolicy.accept(RetryPolicy.getDefault());
-    }
-
-    String proxyHost = config.getString("otel.exporter.otlp." + dataType + ".proxy.host");
-    Integer proxyPort = config.getInt("otel.exporter.otlp." + dataType + ".proxy.port");
-    if (proxyHost != null && proxyPort != null) {
-      setProxy.accept(ProxyOptions.builder(proxyHost, proxyPort).build());
     }
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
@@ -51,8 +51,7 @@ public class OtlpLogRecordExporterProvider
           builder::setTimeout,
           builder::setTrustedCertificates,
           builder::setClientTls,
-          builder::setRetryPolicy,
-          builder::setProxy);
+          builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
@@ -68,8 +67,7 @@ public class OtlpLogRecordExporterProvider
           builder::setTimeout,
           builder::setTrustedCertificates,
           builder::setClientTls,
-          builder::setRetryPolicy,
-          builder::setProxy);
+          builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
@@ -43,8 +43,7 @@ public class OtlpMetricExporterProvider implements ConfigurableMetricExporterPro
           builder::setTimeout,
           builder::setTrustedCertificates,
           builder::setClientTls,
-          builder::setRetryPolicy,
-          builder::setProxy);
+          builder::setRetryPolicy);
       OtlpConfigUtil.configureOtlpAggregationTemporality(
           config, builder::setAggregationTemporalitySelector);
       OtlpConfigUtil.configureOtlpHistogramDefaultAggregation(
@@ -63,8 +62,7 @@ public class OtlpMetricExporterProvider implements ConfigurableMetricExporterPro
           builder::setTimeout,
           builder::setTrustedCertificates,
           builder::setClientTls,
-          builder::setRetryPolicy,
-          builder::setProxy);
+          builder::setRetryPolicy);
       OtlpConfigUtil.configureOtlpAggregationTemporality(
           config, builder::setAggregationTemporalitySelector);
       OtlpConfigUtil.configureOtlpHistogramDefaultAggregation(

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
@@ -50,8 +50,7 @@ public class OtlpSpanExporterProvider
           builder::setTimeout,
           builder::setTrustedCertificates,
           builder::setClientTls,
-          builder::setRetryPolicy,
-          builder::setProxy);
+          builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
@@ -67,8 +66,7 @@ public class OtlpSpanExporterProvider
           builder::setTimeout,
           builder::setTrustedCertificates,
           builder::setClientTls,
-          builder::setRetryPolicy,
-          builder::setProxy);
+          builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -17,7 +17,6 @@ import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.time.Duration;
@@ -189,13 +188,6 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   public OtlpGrpcLogRecordExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
     requireNonNull(retryPolicy, "retryPolicy");
     delegate.setRetryPolicy(retryPolicy);
-    return this;
-  }
-
-  /** Sets the proxy to be used. */
-  public OtlpGrpcLogRecordExporterBuilder setProxy(ProxyOptions proxyOptions) {
-    requireNonNull(proxyOptions, "proxyOptions");
-    delegate.setProxy(proxyOptions);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
@@ -233,12 +232,6 @@ public final class OtlpGrpcMetricExporterBuilder {
   public OtlpGrpcMetricExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
     requireNonNull(retryPolicy, "retryPolicy");
     delegate.setRetryPolicy(retryPolicy);
-    return this;
-  }
-
-  /** Sets the proxy to be used. */
-  public OtlpGrpcMetricExporterBuilder setProxy(ProxyOptions proxyOptions) {
-    requireNonNull(proxyOptions, "proxyOptions");
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -17,7 +17,6 @@ import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.time.Duration;
@@ -186,13 +185,6 @@ public final class OtlpGrpcSpanExporterBuilder {
   public OtlpGrpcSpanExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
     requireNonNull(retryPolicy, "retryPolicy");
     delegate.setRetryPolicy(retryPolicy);
-    return this;
-  }
-
-  /** Sets the proxy to be used. */
-  public OtlpGrpcSpanExporterBuilder setProxy(ProxyOptions proxyOptions) {
-    requireNonNull(proxyOptions, "proxyOptions");
-    delegate.setProxy(proxyOptions);
     return this;
   }
 

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtilTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtilTest.java
@@ -325,7 +325,6 @@ class OtlpConfigUtilTest {
         value -> {},
         value -> {},
         (value1, value2) -> {},
-        value -> {},
         value -> {});
 
     return endpoint.get();

--- a/exporters/otlp/testing-internal/build.gradle.kts
+++ b/exporters/otlp/testing-internal/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation("com.linecorp.armeria:armeria-junit5")
   implementation("io.github.netmikey.logunit:logunit-jul")
   implementation("org.assertj:assertj-core")
+  implementation("org.mock-server:mockserver-netty")
 }
 
 // Skip OWASP dependencyCheck task on test module

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -840,7 +840,6 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                   + "timeoutNanos="
                   + TimeUnit.SECONDS.toNanos(10)
                   + ", "
-                  + "proxyOptions=null, "
                   + "compressorEncoding=null, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}"
                   + ".*" // Maybe additional grpcChannel field
@@ -878,7 +877,6 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                   + "timeoutNanos="
                   + TimeUnit.SECONDS.toNanos(5)
                   + ", "
-                  + "proxyOptions=null, "
                   + "compressorEncoding=gzip, "
                   + "headers=Headers\\{.*foo=OBFUSCATED.*\\}, "
                   + "retryPolicy=RetryPolicy\\{maxAttempts=2, initialBackoff=PT0\\.05S, maxBackoff=PT3S, backoffMultiplier=1\\.3\\}"

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -39,12 +39,14 @@ import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.cert.CertificateEncodingException;
@@ -84,6 +86,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockserver.integration.ClientAndServer;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
 
@@ -653,6 +656,39 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
     }
 
     assertThat(attempts).hasValue(1);
+  }
+
+  @Test
+  void proxy() {
+    // configure mockserver to proxy to the local OTLP server
+    InetSocketAddress serverSocketAddress = server.httpSocketAddress();
+    try (ClientAndServer clientAndServer =
+        ClientAndServer.startClientAndServer(
+            serverSocketAddress.getHostName(), serverSocketAddress.getPort())) {
+      TelemetryExporter<T> exporter =
+          exporterBuilder()
+              // Configure exporter with server endpoint, and proxy options to route through
+              // mockserver proxy
+              .setEndpoint(server.httpUri() + path)
+              .setProxyOptions(
+                  ProxyOptions.create(
+                      InetSocketAddress.createUnresolved("localhost", clientAndServer.getPort())))
+              .build();
+
+      try {
+        List<T> telemetry = Collections.singletonList(generateFakeTelemetry());
+
+        assertThat(exporter.export(telemetry).join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+        // assert that mock server received request
+        assertThat(clientAndServer.retrieveRecordedRequests(new org.mockserver.model.HttpRequest()))
+            .hasSize(1);
+        // assert that server received telemetry from proxy, and is as expected
+        List<U> expectedResourceTelemetry = toProto(telemetry);
+        assertThat(exportedResourceTelemetry).containsExactlyElementsOf(expectedResourceTelemetry);
+      } finally {
+        exporter.shutdown();
+      }
+    }
   }
 
   @Test

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
@@ -104,9 +104,8 @@ final class GrpcLogRecordExporterBuilderWrapper implements TelemetryExporterBuil
   }
 
   @Override
-  public TelemetryExporterBuilder<LogRecordData> setProxy(ProxyOptions proxyOptions) {
-    builder.setProxy(proxyOptions);
-    return this;
+  public TelemetryExporterBuilder<LogRecordData> setProxyOptions(ProxyOptions proxyOptions) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
@@ -104,9 +104,8 @@ final class GrpcMetricExporterBuilderWrapper implements TelemetryExporterBuilder
   }
 
   @Override
-  public TelemetryExporterBuilder<MetricData> setProxy(ProxyOptions proxyOptions) {
-    builder.setProxy(proxyOptions);
-    return this;
+  public TelemetryExporterBuilder<MetricData> setProxyOptions(ProxyOptions proxyOptions) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
@@ -105,9 +105,8 @@ final class GrpcSpanExporterBuilderWrapper implements TelemetryExporterBuilder<S
   }
 
   @Override
-  public TelemetryExporterBuilder<SpanData> setProxy(ProxyOptions proxyOptions) {
-    builder.setProxy(proxyOptions);
-    return this;
+  public TelemetryExporterBuilder<SpanData> setProxyOptions(ProxyOptions proxyOptions) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpLogRecordExporterBuilderWrapper.java
@@ -108,8 +108,8 @@ public class HttpLogRecordExporterBuilderWrapper
   }
 
   @Override
-  public TelemetryExporterBuilder<LogRecordData> setProxy(ProxyOptions proxyOptions) {
-    builder.setProxy(proxyOptions);
+  public TelemetryExporterBuilder<LogRecordData> setProxyOptions(ProxyOptions proxyOptions) {
+    builder.setProxyOptions(proxyOptions);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpMetricExporterBuilderWrapper.java
@@ -107,8 +107,8 @@ public class HttpMetricExporterBuilderWrapper implements TelemetryExporterBuilde
   }
 
   @Override
-  public TelemetryExporterBuilder<MetricData> setProxy(ProxyOptions proxyOptions) {
-    builder.setProxy(proxyOptions);
+  public TelemetryExporterBuilder<MetricData> setProxyOptions(ProxyOptions proxyOptions) {
+    builder.setProxyOptions(proxyOptions);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpSpanExporterBuilderWrapper.java
@@ -107,7 +107,7 @@ public class HttpSpanExporterBuilderWrapper implements TelemetryExporterBuilder<
   }
 
   @Override
-  public TelemetryExporterBuilder<SpanData> setProxy(ProxyOptions proxyOptions) {
+  public TelemetryExporterBuilder<SpanData> setProxyOptions(ProxyOptions proxyOptions) {
     builder.setProxy(proxyOptions);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -153,8 +153,8 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   }
 
   @Override
-  public TelemetryExporterBuilder<T> setProxy(ProxyOptions proxyOptions) {
-    delegate.setProxy(proxyOptions);
+  public TelemetryExporterBuilder<T> setProxyOptions(ProxyOptions proxyOptions) {
+    delegate.setProxyOptions(proxyOptions);
     return this;
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
@@ -61,7 +61,7 @@ public interface TelemetryExporterBuilder<T> {
 
   TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy);
 
-  TelemetryExporterBuilder<T> setProxy(ProxyOptions proxyOptions);
+  TelemetryExporterBuilder<T> setProxyOptions(ProxyOptions proxyOptions);
 
   TelemetryExporterBuilder<T> setChannel(Object channel);
 

--- a/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
+++ b/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
@@ -15,7 +15,6 @@ import io.opentelemetry.exporter.internal.grpc.GrpcSender;
 import io.opentelemetry.exporter.internal.grpc.GrpcSenderProvider;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,7 +42,6 @@ public class UpstreamGrpcSenderProvider implements GrpcSenderProvider {
       @Nullable Compressor compressor,
       long timeoutNanos,
       Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable ProxyOptions proxyOptions,
       @Nullable Object managedChannel,
       Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       @Nullable RetryPolicy retryPolicy,

--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
@@ -15,8 +15,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.net.InetSocketAddress;
-import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -120,8 +118,7 @@ public final class JdkHttpSender implements HttpSender {
       builder.sslContext(sslContext);
     }
     if (proxyOptions != null) {
-      builder.proxy(
-          ProxySelector.of(new InetSocketAddress(proxyOptions.getHost(), proxyOptions.getPort())));
+      builder.proxy(proxyOptions.getProxySelector());
     }
     return builder.build();
   }

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -31,12 +31,8 @@ import io.opentelemetry.exporter.internal.grpc.GrpcResponse;
 import io.opentelemetry.exporter.internal.grpc.GrpcSender;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -80,7 +76,6 @@ public final class OkHttpGrpcSender<T extends Marshaler> implements GrpcSender<T
       @Nullable Compressor compressor,
       long timeoutNanos,
       Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable ProxyOptions proxyOptions,
       @Nullable RetryPolicy retryPolicy,
       @Nullable SSLContext sslContext,
       @Nullable X509TrustManager trustManager) {
@@ -99,12 +94,6 @@ public final class OkHttpGrpcSender<T extends Marshaler> implements GrpcSender<T
       clientBuilder.protocols(Collections.singletonList(Protocol.H2_PRIOR_KNOWLEDGE));
     } else {
       clientBuilder.protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
-    }
-    if (proxyOptions != null) {
-      SocketAddress proxyAddress =
-          new InetSocketAddress(proxyOptions.getHost(), proxyOptions.getPort());
-      Proxy proxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
-      clientBuilder.proxy(proxy);
     }
     this.client = clientBuilder.build();
     this.headersSupplier = headersSupplier;

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
@@ -11,7 +11,6 @@ import io.opentelemetry.exporter.internal.grpc.GrpcSender;
 import io.opentelemetry.exporter.internal.grpc.GrpcSenderProvider;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.util.List;
@@ -37,7 +36,6 @@ public class OkHttpGrpcSenderProvider implements GrpcSenderProvider {
       @Nullable Compressor compressor,
       long timeoutNanos,
       Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable ProxyOptions proxyOptions,
       @Nullable Object managedChannel,
       Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       @Nullable RetryPolicy retryPolicy,
@@ -48,7 +46,6 @@ public class OkHttpGrpcSenderProvider implements GrpcSenderProvider {
         compressor,
         timeoutNanos,
         headersSupplier,
-        proxyOptions,
         retryPolicy,
         sslContext,
         trustManager);

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
@@ -15,9 +15,6 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -74,10 +71,7 @@ public final class OkHttpHttpSender implements HttpSender {
             .callTimeout(Duration.ofNanos(timeoutNanos));
 
     if (proxyOptions != null) {
-      SocketAddress proxyAddress =
-          new InetSocketAddress(proxyOptions.getHost(), proxyOptions.getPort());
-      Proxy proxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
-      builder.proxy(proxy);
+      builder.proxySelector(proxyOptions.getProxySelector());
     }
 
     if (authenticator != null) {

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSuppressionTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSuppressionTest.java
@@ -21,7 +21,7 @@ class OkHttpGrpcSuppressionTest
   @Override
   OkHttpGrpcSender<DummyMarshaler> createSender(String endpoint) {
     return new OkHttpGrpcSender<>(
-        "https://localhost", null, 10L, Collections::emptyMap, null, null, null, null);
+        "https://localhost", null, 10L, Collections::emptyMap, null, null, null);
   }
 
   protected static class DummyMarshaler extends MarshalerWithSize {


### PR DESCRIPTION
- ProxyOptions exposes ProxySelector
- Remove proxy settings from OtlpGrpc{Signal}ExporterBuilder
- Remove proxy autoconfigure settings
- Add proxy e2e test with mock server

Per my proposal [here](https://github.com/open-telemetry/opentelemetry-java/pull/6206#issuecomment-1967510882).

Notably, I removed the env var options for `otel.exporter.otlp.*.proxy.host.*`. The env variables we support are bounded by the spec (the relevant file for these options is [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md)), so we'd need to get the spec updated before including these.